### PR TITLE
make sure that options set via answers have the same "level", ie, the…

### DIFF
--- a/cmd/drawbridge/drawbridge.go
+++ b/cmd/drawbridge/drawbridge.go
@@ -473,7 +473,8 @@ func createFlagHandler(appConfig config.Interface, answerValues map[string]inter
 		//check if the key is set as an answer/default
 		if answerOptionValue, ok := answerValues[optionName]; ok {
 			//this answer is actuall for an option. lets set it.
-			appConfig.Set(fmt.Sprintf("options.%v", optionName), answerOptionValue)
+			//fmt.Printf("Setting Option from Answer: %v  (%v)", optionName, answerOptionValue)
+			appConfig.SetDefault(fmt.Sprintf("options.%v", optionName), answerOptionValue)
 		}
 	}
 


### PR DESCRIPTION
…y are set as defaults, otherwise the whole "options" block will be overridden